### PR TITLE
Allow plugin to work in more cases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,18 +24,28 @@ plugins:
 ## Usage
 
 Add the parameter `enabled: false` to a function to disable it.
-This allows you to enable/disable functions by stage like so:
+Add the parameter `disabled: true` to an event to disable it.
+This allows you to enable/disable functions/events by stage like so:
 
 ```yaml
 service: hello-service
 provider: aws
 custom:
+  hello_event_disabled:
+    dev: true
+    qa: true
+    prod: false
   hello_enabled:
     dev: true
+    qa: false
     prod: false
 
 functions:
   hello:
     handler: handler.hello
     enabled: ${self:custom.hello_enabled.${opt:stage}}
+    events:
+      - sns:
+        displayName: test event
+        disabled: ${self:custom.hello_event_disabled.${opt:stage}}
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -1,30 +1,14 @@
 'use strict';
 
-const providers = [
-  'aws',
-  'azure',
-  'aliyun',
-  'cloudflare',
-  'fn',
-  'google',
-  'knative',
-  'kubeless',
-  'openwhisk',
-  'spotinst',
-  'tencent',
-];
-
 class ServerlessDisableFunctionPlugin {
   constructor(serverless) {
     this.serverless = serverless;
 
-    // Add a validation for each of the standard providers
-    providers.forEach((provider) => {
-      serverless.configSchemaHandler.defineFunctionProperties(provider, {
-        properties: {
-          enabled: { type: 'boolean' },
-        },
-      });
+    // Add validation for functions.
+    serverless.configSchemaHandler.defineFunctionProperties(serverless.service.provider.name, {
+      properties: {
+        enabled: { type: 'boolean' },
+      },
     });
     this.hooks = { 'before:package:initialize': this.run.bind(this) };
   }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,27 @@ class ServerlessDisableFunctionPlugin {
         enabled: { type: 'boolean' },
       },
     });
+
+    // Add validation for events.  We use disabled here because enabled has existing meanings.
+    Object.entries(
+      serverless.configSchemaHandler.schema.properties.functions.patternProperties
+    ).forEach(([, obj]) => {
+      Object.entries(obj.properties.events.items.anyOf).forEach(([, item]) => {
+        if (item.required == '__schemaWorkaround__') {
+          // Must be skipped, or we fail.
+          return;
+        }
+        serverless.configSchemaHandler.defineFunctionEventProperties(
+          serverless.service.provider.name,
+          item.required[0],
+          {
+            properties: {
+              disabled: { type: `boolean` },
+            },
+          }
+        );
+      });
+    });
     this.hooks = { 'before:package:initialize': this.run.bind(this) };
   }
 
@@ -18,6 +39,15 @@ class ServerlessDisableFunctionPlugin {
       if (func.enabled !== undefined && !func.enabled) {
         this.serverless.cli.log('Disabling function: ' + key);
         delete this.serverless.service.functions[key];
+      } else {
+        Object.entries(func.events).forEach(([i, event]) => {
+          Object.entries(event).forEach(([ekey, e]) => {
+            if (e.disabled !== undefined && e.disabled) {
+              this.serverless.cli.log(`Disabling function '${key}' event '${ekey}'.`);
+              delete this.serverless.service.functions[key].events[i][ekey];
+            }
+          });
+        });
       }
     });
   }


### PR DESCRIPTION
This PR does two things.

The first (and less significant) change is that it replaces the static list of standard providers, and uses a runtime variable to add the enabled parameter to functions in whatever the current provider is.

The second change extends the plugin to allow it to disable events as well as functions.

Critically, the keyword for disabling events is 'disabled: true' not 'enabled: false', this is because 'enabled' already exists for some AWS event types. (sqs has it, sns does not)