### PR TITLE
fix: support all serverless framework versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   test:
@@ -10,8 +14,11 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: npm
 
       - run: npm ci
       - run: npx biome ci .
+      - run: npm test
+        env:
+          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ node_modules/
 
 # Serverless directories
 .serverless/
+
+# Test framework workspaces
+test/*/package-lock.json
+test/*/.fixture-*
+
+# Local environment
+.env

--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ functions:
     handler: handler.hello
     enabled: ${self:custom.hello_enabled.${opt:stage}}
 ```
+
+## Compatibility
+
+Works with every version of the Serverless Framework from v1.12 up to and including v4,
+as well as [osls](https://github.com/oss-serverless/osls).

--- a/biome.json
+++ b/biome.json
@@ -14,5 +14,17 @@
       "quoteStyle": "single",
       "trailingCommas": "es5"
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["src/**"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "useOptionalChain": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "description": "A simple serverless plugin to disable functions.",
   "scripts": {
     "prepare": "husky",
-    "lint": "biome check ."
+    "lint": "biome check .",
+    "test": "node --env-file-if-exists=.env --test test/*.test.js"
   },
   "main": "src/index.js",
   "type": "commonjs",
+  "files": [
+    "src"
+  ],
   "devDependencies": {
     "@biomejs/biome": "^2.5.7",
     "husky": "^9.1.7"

--- a/src/index.js
+++ b/src/index.js
@@ -1,39 +1,35 @@
 'use strict';
 
-const providers = [
-  'aws',
-  'azure',
-  'aliyun',
-  'cloudflare',
-  'fn',
-  'google',
-  'knative',
-  'kubeless',
-  'openwhisk',
-  'spotinst',
-  'tencent',
-];
-
 class ServerlessDisableFunctionPlugin {
-  constructor(serverless) {
+  constructor(serverless, _options, utils) {
     this.serverless = serverless;
 
-    // Add a validation for each of the standard providers
-    providers.forEach((provider) => {
-      serverless.configSchemaHandler.defineFunctionProperties(provider, {
-        properties: {
-          enabled: { type: 'boolean' },
-        },
+    if (utils && utils.log) {
+      // v3+ passes a logging interface to the plugin constructor.
+      this.log = utils.log.notice.bind(utils.log);
+    } else {
+      // v1 and v2 expose the legacy CLI logger.
+      this.log = serverless.cli.log.bind(serverless.cli);
+    }
+
+    // defineFunctionProperties only exists since v2; older versions leave `enabled` unvalidated.
+    const schema = serverless.configSchemaHandler;
+    if (schema && typeof schema.defineFunctionProperties === 'function') {
+      schema.defineFunctionProperties(serverless.service.provider.name, {
+        properties: { enabled: { type: 'boolean' } },
       });
-    });
+    }
+
     this.hooks = { 'before:package:initialize': this.run.bind(this) };
   }
 
   run() {
-    Object.entries(this.serverless.service.functions).forEach(([key, func]) => {
-      if (func.enabled !== undefined && !func.enabled) {
-        this.serverless.cli.log('Disabling function: ' + key);
-        delete this.serverless.service.functions[key];
+    const functions = this.serverless.service.functions;
+    Object.keys(functions).forEach((name) => {
+      const fn = functions[name];
+      if (fn.enabled !== undefined && !fn.enabled) {
+        this.log(`Disabling function: ${name}`);
+        delete functions[name];
       }
     });
   }

--- a/test/fixture/handler.js
+++ b/test/fixture/handler.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports.hello = async () => ({ statusCode: 200 });

--- a/test/fixture/serverless.yml
+++ b/test/fixture/serverless.yml
@@ -1,0 +1,29 @@
+service: fixture
+configValidationMode: error
+
+provider:
+  name: aws
+  # An explicit bucket stops v4 resolving deployment state from AWS during `package`.
+  deploymentBucket:
+    name: fake-test-bucket
+
+custom:
+  stageToggledEnabled:
+    dev: true
+    prod: false
+
+plugins:
+  - serverless-disable-functions
+
+functions:
+  alwaysOn:
+    handler: handler.hello
+  explicitlyEnabled:
+    handler: handler.hello
+    enabled: true
+  disabled:
+    handler: handler.hello
+    enabled: false
+  stageToggled:
+    handler: handler.hello
+    enabled: ${self:custom.stageToggledEnabled.${opt:stage}}

--- a/test/osls-v4.test.js
+++ b/test/osls-v4.test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { runTests } = require('./utils');
+
+runTests('osls-v4');

--- a/test/osls-v4/package.json
+++ b/test/osls-v4/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "osls-v4",
+  "private": true,
+  "devDependencies": {
+    "osls": "4",
+    "serverless-disable-functions": "file:../.."
+  }
+}

--- a/test/serverless-v1.test.js
+++ b/test/serverless-v1.test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { runTests } = require('./utils');
+
+runTests('serverless-v1');

--- a/test/serverless-v1/package.json
+++ b/test/serverless-v1/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "serverless-v1",
+  "private": true,
+  "devDependencies": {
+    "serverless": "1",
+    "serverless-disable-functions": "file:../.."
+  }
+}

--- a/test/serverless-v2.test.js
+++ b/test/serverless-v2.test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { runTests } = require('./utils');
+
+runTests('serverless-v2');

--- a/test/serverless-v2/package.json
+++ b/test/serverless-v2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "serverless-v2",
+  "private": true,
+  "devDependencies": {
+    "serverless": "2",
+    "serverless-disable-functions": "file:../.."
+  }
+}

--- a/test/serverless-v3.test.js
+++ b/test/serverless-v3.test.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { runTests } = require('./utils');
+
+runTests('serverless-v3');

--- a/test/serverless-v3/package.json
+++ b/test/serverless-v3/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "serverless-v3",
+  "private": true,
+  "devDependencies": {
+    "serverless": "3",
+    "serverless-disable-functions": "file:../.."
+  }
+}

--- a/test/serverless-v4.test.js
+++ b/test/serverless-v4.test.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const { runTests } = require('./utils');
+
+// serverless v4 refuses to run without an account; skip rather than fail when no key is
+// available (e.g. on fork PRs, where repository secrets are withheld).
+runTests('serverless-v4', {
+  skip: process.env.SERVERLESS_ACCESS_KEY ? false : 'SERVERLESS_ACCESS_KEY is not set',
+});

--- a/test/serverless-v4/package.json
+++ b/test/serverless-v4/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "serverless-v4",
+  "private": true,
+  "devDependencies": {
+    "serverless": "4",
+    "serverless-disable-functions": "file:../.."
+  }
+}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,83 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { before, describe, it } = require('node:test');
+
+function runPackage(workspace, stage) {
+  const serviceDir = fs.mkdtempSync(path.join(workspace, `.fixture-${stage}-`));
+  try {
+    fs.cpSync(path.join(__dirname, 'fixture'), serviceDir, { recursive: true });
+
+    const result = spawnSync(
+      path.join(workspace, 'node_modules', '.bin', 'serverless'),
+      ['package', '--stage', stage],
+      { cwd: serviceDir, encoding: 'utf8' }
+    );
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `'serverless package' failed (stage ${stage}):\n${result.stdout}\n${result.stderr}`
+      );
+    }
+
+    const template = JSON.parse(
+      fs.readFileSync(
+        path.join(serviceDir, '.serverless', 'cloudformation-template-update-stack.json'),
+        'utf8'
+      )
+    );
+    const functions = Object.values(template.Resources)
+      .filter((resource) => resource.Type === 'AWS::Lambda::Function')
+      .map((resource) => resource.Properties.FunctionName)
+      .sort();
+
+    // v1 and v2 log to stdout, v3+ to stderr.
+    return { functions, output: result.stdout + result.stderr };
+  } finally {
+    fs.rmSync(serviceDir, { recursive: true, force: true });
+  }
+}
+
+function runTests(name, options) {
+  const workspace = path.join(__dirname, name);
+
+  describe(`serverless-disable-functions with ${name}`, options || {}, () => {
+    before(() => {
+      const result = spawnSync('npm', ['install', '--no-audit', '--no-fund'], {
+        cwd: workspace,
+        encoding: 'utf8',
+      });
+      if (result.error) {
+        throw result.error;
+      }
+      if (result.status !== 0) {
+        throw new Error(`npm install failed in ${workspace}:\n${result.stdout}\n${result.stderr}`);
+      }
+    });
+
+    it('keeps enabled functions and removes disabled ones', () => {
+      const { functions, output } = runPackage(workspace, 'dev');
+      assert.deepEqual(functions, [
+        'fixture-dev-alwaysOn',
+        'fixture-dev-explicitlyEnabled',
+        'fixture-dev-stageToggled',
+      ]);
+      assert.match(output, /Disabling function: disabled/);
+      assert.doesNotMatch(output, /Disabling function: stageToggled/);
+    });
+
+    it('removes a stage-toggled function in a stage where it is disabled', () => {
+      const { functions, output } = runPackage(workspace, 'prod');
+      assert.deepEqual(functions, ['fixture-prod-alwaysOn', 'fixture-prod-explicitlyEnabled']);
+      assert.match(output, /Disabling function: disabled/);
+      assert.match(output, /Disabling function: stageToggled/);
+    });
+  });
+}
+
+module.exports = { runTests };


### PR DESCRIPTION
- Guard the config schema registration: defineFunctionProperties only exists since serverless v2, so the plugin crashed on all of v1
- Register the schema for the service's actual provider instead of a hard-coded provider list
- Use the v3+ logging interface when available, falling back to the legacy CLI logger on older versions
- Add integration tests packaging a fixture against serverless v1-v4 and osls, asserting on the compiled template and log output
- Document supported framework versions in the README
